### PR TITLE
Fix composer plugin api requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     "psr-0": { "OpenEyes\\Composer\\": "src/" }
   },
   "require": {
-    "composer-plugin-api": "1.0.0"
+    "composer-plugin-api": "^1.0.0"
   }
 }


### PR DESCRIPTION
Without this patch if we bump the composer plugin API to 1.1+ your plugin won't be installable anymore.
